### PR TITLE
Rhythmbox 3

### DIFF
--- a/seek.plugin
+++ b/seek.plugin
@@ -1,5 +1,5 @@
 [Plugin]
-Loader=python
+Loader=python3
 Module=seek
 IAge=2
 Name=Seek

--- a/seek/__init__.py
+++ b/seek/__init__.py
@@ -55,6 +55,12 @@ class TrackSeekPlugin(GObject.Object, Peas.Activatable):
         app.add_plugin_menu_item("tools", "tools" + action_name, item)
         app.set_accels_for_action("win." + action_name, [accel])
 
+    def remove_action(self, action_name):
+        app = Gio.Application.get_default()
+        app.set_accels_for_action("win." + action_name, [])
+        app.remove_plugin_menu_item("tools", "tools" + action_name)
+        self.object.props.window.remove_action(action_name)
+
     def do_activate(self):
         print("Activating Plugin")
         self.add_action(self.bwd_action_name, self.bwd_menu_name,
@@ -95,10 +101,6 @@ class TrackSeekPlugin(GObject.Object, Peas.Activatable):
 
     def do_deactivate(self):
         print("De-activating Plugin")
-        app = Gio.Application.get_default()
-        app.set_accels_for_action("win." + self.fwd_action_name, [])
-        app.set_accels_for_action("win." + self.bwd_action_name, [])
-        app.remove_plugin_menu_item("tools", "tools" + self.fwd_action_name)
-        app.remove_plugin_menu_item("tools", "tools" + self.bwd_action_name)
-        self.object.props.window.remove_action(self.fwd_action_name)
-        self.object.props.window.remove_action(self.bwd_action_name)
+        self.remove_action(self.fwd_action_name)
+        self.remove_action(self.bwd_action_name)
+

--- a/seek/__init__.py
+++ b/seek/__init__.py
@@ -3,7 +3,7 @@
 # shortcuts) to seek forward (10 secs) / backward (5 secs)
 # in the currently playing track.
 #
-# VERSION 1.0
+# VERSION 2.0
 #
 
 # Copyright 2013 Cathal Garvey. http://cgarvey.ie/


### PR DESCRIPTION
This is an update to use this plugin with current versions of Rhythmbox. Unfortunately I wasn't able to add new menu entries to Control section. It seems that Rhythmbox allows plugins to add only to Tools and Views sections. Hotkeys changed to shift+left, shift+right, аs control button already assigned by default.
Tested it on Ubuntu 16.04 with Rhythmbox 3.3. 